### PR TITLE
fix sed failure on os x

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -6,9 +6,9 @@ build:
 	npm run build
 
 prod:
-	sed -i 's/http:\/\/localhost:3000/http:\/\/dusk.host/' src/Helper.purs
+	sed -i '' 's/http:\/\/localhost:3000/http:\/\/dusk.host/' src/Helper.purs
 
 build_dev:
-	sed -i 's/http:\/\/dusk.host/http:\/\/localhost:3000/' src/Helper.purs
+	sed -i '' 's/http:\/\/dusk.host/http:\/\/localhost:3000/' src/Helper.purs
 	npm run build-dev
 


### PR DESCRIPTION
The -i flag needs an argument over here in apple land.

https://stackoverflow.com/questions/17534840/sed-throws-bad-flag-in-substitute-command